### PR TITLE
265 rewrite regionid test

### DIFF
--- a/.github/workflows/run_translations_test.yaml
+++ b/.github/workflows/run_translations_test.yaml
@@ -1,10 +1,10 @@
 on:
-  workflow_dispatch:
+  workflow_dispatch: 
   pull_request:
     branches:
       - 'uat'
     paths:
-      - 'data/output/UAT_processing/Vespa_velutina_shape/**'
+      - 'data/output/UAT_processing/**'
       - 'data/output/UAT_direct/**'
   
 

--- a/.github/workflows/run_translations_test.yaml
+++ b/.github/workflows/run_translations_test.yaml
@@ -5,6 +5,7 @@ on:
       - 'uat'
     paths:
       - 'data/output/UAT_processing/Vespa_velutina_shape/**'
+      - 'data/output/UAT_direct/**'
   
 
 name: run_translations_test
@@ -37,12 +38,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - name: Install linux libraries
+  - name: Install linux libraries
         run: |
-          sudo apt install libsodium-dev
-          sudo apt-get install libcurl4-openssl-dev
-          sudo apt-get install libgdal-dev libproj-dev
-          sudo apt install libudunits2-dev
+          sudo apt-get update
+          sudo apt-get install -y libsodium-dev libcurl4-openssl-dev libgdal-dev libproj-dev libudunits2-dev
      
       - name: Test translations
         run: |

--- a/.github/workflows/run_translations_test.yaml
+++ b/.github/workflows/run_translations_test.yaml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'data/output/UAT_processing/**'
       - 'data/output/UAT_direct/**'
-  
 
 name: run_translations_test
 
@@ -38,7 +37,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-  - name: Install linux libraries
+      - name: Install linux libraries
         run: |
           sudo apt-get update
           sudo apt-get install -y libsodium-dev libcurl4-openssl-dev libgdal-dev libproj-dev libudunits2-dev
@@ -47,5 +46,3 @@ jobs:
         run: |
           source("src/tests/test_regionIDs.R")
         shell: Rscript {0}
-          
-      

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -14,8 +14,9 @@ for(package in packages) {
 #List the datasets to test
 #-------------------------------------------------------------------------
 #Specify folders holding the datasets to test
-folders<-c("./data/output/UAT_processing/Vespa_velutina_shape",
-           "./data/output/UAT_direct")
+folders<-c("./data/output/UAT_processing",
+           "./data/output/UAT_direct",
+           "./data/output/UAT_direct/Vespa_velutina_shape")
 
 #List files in those folders
 datasets <- unlist(lapply(folders, function(folder) {

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -2,7 +2,7 @@
 #Load package testthat, and install it when this has not been done before
 #-------------------------------------------------------------------------
 
-packages <- c("testthat","sf","utils","readr")
+packages <- c("testthat","sf","utils","readr","here")
 
 for(i in packages) {
   if( ! i %in% rownames(installed.packages()) ) { install.packages( i ) }

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -30,7 +30,9 @@ datasets<-datasets[!datasets %in% c("./data/output/UAT_direct/translations_simpl
                                     "./data/output/UAT_direct/harmonia_info.csv",
                                     "./data/output/UAT_processing/Vespa_velutina_shape/aantal_nesten_meta.csv",
                                     "./data/output/UAT_processing/be_alientaxa_cube.csv",
-                                    "./data/output/UAT_processing/be_alientaxa_info.csv")
+                                    "./data/output/UAT_processing/be_alientaxa_info.csv",
+                                    "./data/output/UAT_processing/communes.geojson",
+                                    "./data/output/UAT_processing/provinces.geojson")
 ]
 
 

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -92,10 +92,16 @@ test_that("Region names and columns are indicated correctly in files", {
         
         translation_IDs_okay<-length(wrong_translations)==0
         
+        
         # Expect that all values are present
-        expect_true(translation_IDs_okay, info = paste0("The following values in column ", level, " in the file ", datasetname,filetype, " are not present in translations_regions:", paste(wrong_translations, collapse = ", ")))
+        expect_true(translation_IDs_okay, info = paste0("The following values in column ", level, " in the file ", datasetname,".",extension, " are not present in translations_regions: ", paste(wrong_translations, collapse = ", ")))
+        
       }
     }
   }
 })
 
+
+
+
+    

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -41,13 +41,11 @@ region_values <- translations_regions$title_id
 
 
 #-------------------------------------------------------------------------
-# Define the test
+# Define the tests
 #-------------------------------------------------------------------------
 
-test_that("Region IDs in Vespa output files correspond to those in translations_regions file", {
-  
-  # Extract the reference column from translations_regions 
-  region_values <- translations_regions$title_id
+
+test_that("Region names and columns are indicated correctly in files", { 
   
   for(datasetname in names(datasets)){
     filetype <- switch(datasetname,

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -11,21 +11,24 @@ for(package in packages) {
 
 
 #-------------------------------------------------------------------------
-#Load the data of the datasets that you want to test
+#List the datasets to test
 #-------------------------------------------------------------------------
-points <- st_read("./data/output/UAT_processing/Vespa_velutina_shape/points.geojson")
-nesten<- st_read("./data/output/UAT_processing/Vespa_velutina_shape/nesten.geojson")
-aantal_gemelde_nesten<- st_read("./data/output/UAT_processing/Vespa_velutina_shape/aantal_gemelde_nesten.geojson")
-aantal_lente_nesten<- read.csv("./data/output/UAT_processing/Vespa_velutina_shape/aantal_lente_nesten.csv")
-actieve_haarden<- st_read("./data/output/UAT_processing/Vespa_velutina_shape/actieve_haarden.geojson")
-beheerde_nesten<- st_read("./data/output/UAT_processing/Vespa_velutina_shape/beheerde_nesten.geojson")
-onbehandelde_nesten<- st_read("./data/output/UAT_processing/Vespa_velutina_shape/onbehandelde_nesten.geojson")
+#Specify folders holding the datasets to test
+folders<-c("./data/output/UAT_processing/Vespa_velutina_shape",
+           "./data/output/UAT_direct")
 
+#List files in those folders
+datasets <- unlist(lapply(folders, function(folder) {
+  list.files(folder, pattern = "\\.(geojson|csv)$", full.names = TRUE)
+}))
 
-#-------------------------------------------------------------------------
-#Load the translations file
-#-------------------------------------------------------------------------
-translations_regions<-read.csv2("./data/output/UAT_direct/translations_regions.csv")
+#Remove certain files that don't need to be checked
+datasets<-datasets[!datasets %in% c("./data/output/UAT_direct/translations_simple.csv",
+                                    "./data/output/UAT_direct/translations_regions.csv",
+                                    "./data/output/UAT_direct/translations.csv",
+                                    "./data/output/UAT_direct/harmonia_info.csv",
+                                    "./data/output/UAT_processing/Vespa_velutina_shape/aantal_nesten_meta.csv")
+]
 
 
 #-------------------------------------------------------------------------

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -28,7 +28,9 @@ datasets<-datasets[!datasets %in% c("./data/output/UAT_direct/translations_simpl
                                     "./data/output/UAT_direct/translations_regions.csv",
                                     "./data/output/UAT_direct/translations.csv",
                                     "./data/output/UAT_direct/harmonia_info.csv",
-                                    "./data/output/UAT_processing/Vespa_velutina_shape/aantal_nesten_meta.csv")
+                                    "./data/output/UAT_processing/Vespa_velutina_shape/aantal_nesten_meta.csv",
+                                    "./data/output/UAT_processing/be_alientaxa_cube.csv",
+                                    "./data/output/UAT_processing/be_alientaxa_info.csv")
 ]
 
 

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -4,9 +4,9 @@
 
 packages <- c("testthat","sf","utils","readr","here")
 
-for(i in packages) {
-  if( ! i %in% rownames(installed.packages()) ) { install.packages( i ) }
-  library(i, character.only = TRUE)
+for(package in packages) {
+  if( ! package %in% rownames(installed.packages()) ) { install.packages( package ) }
+  library(package, character.only = TRUE)
 }
 
 

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -32,10 +32,12 @@ datasets<-datasets[!datasets %in% c("./data/output/UAT_direct/translations_simpl
 
 
 #-------------------------------------------------------------------------
-# create list of datasets
+#Extract region translations
 #-------------------------------------------------------------------------
-datasets <- list(nesten=nesten, points=points, aantal_gemelde_nesten=aantal_gemelde_nesten,aantal_lente_nesten=aantal_lente_nesten,
-                 actieve_haarden=actieve_haarden,beheerde_nesten=beheerde_nesten,onbehandelde_nesten=onbehandelde_nesten)
+translations_regions<-read.csv2(here("data", "output", "UAT_direct", "translations_regions.csv"))
+
+# Extract the reference column from translations_regions 
+region_values <- translations_regions$title_id
 
 
 #-------------------------------------------------------------------------

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -47,18 +47,10 @@ region_values <- translations_regions$title_id
 
 test_that("Region names and columns are indicated correctly in files", { 
   
-  for(datasetname in names(datasets)){
-    filetype <- switch(datasetname,
-                       "nesten" = ".geojson",
-                       "points" = ".geojson",
-                       "aantal_gemelde_nesten" = ".geojson",
-                       "actieve_haarden" = ".geojson",
-                       "beheerde_nesten" = ".geojson",
-                       "onbehandelde_nesten" = ".geojson",
-                       "aantal_lente_nesten" = ".csv",
-                       "")
+  for(i in seq_along(datasets)){
     
-    filename<-datasets[[datasetname]]
+    #Select dataset
+    filename<-datasets[[i]]
     
     for (level in c("level1Name","level2Name","level3Name","NAAM","GEWEST","provincie","Gemeente","prov")){
       

--- a/src/tests/test_regionIDs.R
+++ b/src/tests/test_regionIDs.R
@@ -52,9 +52,39 @@ test_that("Region names and columns are indicated correctly in files", {
     #Select dataset
     filename<-datasets[[i]]
     
-    for (level in c("level1Name","level2Name","level3Name","NAAM","GEWEST","provincie","Gemeente","prov")){
-      
-      if (level %in% colnames(filename)) {
+    #Get datasetname
+    datasetname <- sub(".*/([^/]+)\\.[^.]+$", "\\1", filename)
+    
+    #Get Extension
+    extension <- sub(".*\\.", "", filename)
+    
+    #Read in the data
+    if(extension=="geojson"){
+      #Read in data
+      filename<-st_read(filename, quiet=TRUE)
+    }
+    
+    if(extension=="csv"){
+      #Read in data
+      filename<- suppressMessages(read.csv(filename))
+    }
+    
+    
+    #----------------Check that 'gemeente', 'provincie', and 'gewest', are present in colnames-------------
+    # Extract column names from the dataset
+    column_names <- colnames(filename)
+    
+    # Check if all values are present in the column names
+    all_columns_present<- all(c("gemeente", "provincie", "gewest") %in% column_names)
+    
+    #If not values are present, check which ones are missing
+    missing_columns<- setdiff( c("gemeente", "provincie", "gewest"), column_names)
+    
+    # Run test for column names
+    expect_true(all_columns_present, info = paste0("The following columns are not present in the file ", datasetname,".",extension, ": ", paste(missing_columns, collapse = ", ")))                      
+ 
+    for (level in c("gemeente","provincie","gewest")){
+      if (level %in% column_names) {
         regions_to_check<-filename[[level]]
         
         #Get translations that may not be present in translations_regions


### PR DESCRIPTION
The test has been updated to include a part where column names are checked for the presence of 'gemeente', 'provincie', and 'gewest'.
The region IDs will only be checked if one or multiple of these columns are present. 
The .yaml file has been updated so this workflow will be triggered whenever changes to UAT_direct or Vespa_velutina_shape under UAT_processing are merged with uat.