### PR TITLE
[AUTO] update eu concern list

### DIFF
--- a/.github/workflows/cube_preprocessing.yaml
+++ b/.github/workflows/cube_preprocessing.yaml
@@ -50,6 +50,7 @@ jobs:
           sudo apt-get install libgdal-dev libproj-dev
           sudo apt install libudunits2-dev
           sudo apt install --yes libharfbuzz-dev libfribidi-dev
+          sudo apt-get install -y libfontconfig1-dev
           R --no-save -e 'install.packages("devtools")'
           R --no-save -e 'devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)'
           R --no-save -e 'devtools::install_github("inbo/alien-species-portal@uat", 

--- a/.github/workflows/update_eu_concern_list.yaml
+++ b/.github/workflows/update_eu_concern_list.yaml
@@ -101,7 +101,7 @@ jobs:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat
           title: "[AUTO] update eu concern list"
-          template: .github/PR_PR_update_eu_concern_list.md
+          template: .github/PR_update_eu_concern_list.md
           reviewer: SanderDevisscher
           label: automated workflow
           get_diff: false

--- a/.github/workflows/update_eu_concern_list.yaml
+++ b/.github/workflows/update_eu_concern_list.yaml
@@ -43,6 +43,7 @@ jobs:
           sudo apt-get install libgdal-dev libproj-dev
           sudo apt install libudunits2-dev
           sudo apt install --yes libharfbuzz-dev libfribidi-dev
+          sudo apt-get install -y libfontconfig1-dev
           R --no-save -e 'install.packages("devtools")'
           R --no-save -e 'devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)'
           R --no-save -e 'devtools::install_github("inbo/alien-species-portal@uat", 

--- a/.github/workflows/upload_files_direct.yaml
+++ b/.github/workflows/upload_files_direct.yaml
@@ -48,6 +48,7 @@ jobs:
           sudo apt-get install libgdal-dev libproj-dev
           sudo apt install libudunits2-dev
           sudo apt install --yes libharfbuzz-dev libfribidi-dev
+          sudo apt-get install -y libfontconfig1-dev
           R --no-save -e 'install.packages("devtools")'
           R --no-save -e 'devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)'
           R --no-save -e 'devtools::install_github("inbo/alien-species-portal@uat", 

--- a/.github/workflows/upload_files_processing.yaml
+++ b/.github/workflows/upload_files_processing.yaml
@@ -48,6 +48,7 @@ jobs:
           sudo apt-get install libgdal-dev libproj-dev
           sudo apt install libudunits2-dev
           sudo apt install --yes libharfbuzz-dev libfribidi-dev
+          sudo apt-get install -y libfontconfig1-dev
           R --no-save -e 'install.packages("devtools")'
           R --no-save -e 'devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)'
           R --no-save -e 'devtools::install_github("inbo/alien-species-portal@uat", 


### PR DESCRIPTION
---
editor_options: 
  markdown: 
    wrap: 80
---

## Brief description

This is an **automatically generated PR**. The following steps are all
automatically performed<sup>1</sup>:

-   Compares the eu concern list on the UAT bucket with the main version of
    [trias-project/indicators](https://github.com/trias-project/indicators/blob/main/data/input/eu_concern_species.tsv)
-   Some known issues are fixed when relevant<sup>2</sup>
-   When the list was expanded the new list is exported to `./data/output/`.
-   When the list was changed<sup>3</sup> the modified list is exported to
    `./data/output/`.

All the steps above are triggered by
`./.github/workflows/update_eu_concern_list.yaml` and executed by
`./src/update_eu_concern_list.R`. This script is assisted by
`./src/install_packages_eu_concern_list.R`.

Changes to the PR description can be made at `./.github/PR_management_prep.md`

<sup>1</sup> Set to trigger \"At 00:00 on day-of-month 1 in every month from
January through December.\"

<sup>2</sup> A list of known issues:

1.  *Vespa velutina* is listed on the eu concern list from Trias as *Vespa
    velutina nigrithorax* a subspecies of *Vespa velutina* however on the
    checklist the species-level is used. This script changes the Taxonkey of
    *Vespa velutina nigrithorax* into that of *Vespa velutina* whenever it is
    listed as such. Any changes to `checklist_scientificName` or
    `backbone_taxonKey` annuls this fix.

<sup>3</sup> Checks for the following changes:

1.  New taxonKeys

2.  Changed taxonKeys

3.  Omitted taxonKeys

If any changes have occurred to `./data/output/` the upload to buckets flow will
be triggered after merging this PR.