### PR TITLE
fix issue with devtools

### DIFF
--- a/.github/workflows/get_griis_checklist.yaml
+++ b/.github/workflows/get_griis_checklist.yaml
@@ -48,6 +48,7 @@ jobs:
           sudo apt install libudunits2-dev
           sudo apt install libharfbuzz-dev
           sudo apt install libfribidi-dev
+          sudo apt-get install -y libfontconfig1-dev
 
       - name: Install R packages
         run: |


### PR DESCRIPTION
the installation of devtools fails due to issues with systemfonts adding this line `sudo apt-get install -y libfontconfig1-dev` should fix it. 

if [![get_griis](https://github.com/inbo/aspbo/actions/workflows/get_griis_checklist.yaml/badge.svg?branch=SanderDevisscher-patch-1)](https://github.com/inbo/aspbo/actions/workflows/get_griis_checklist.yaml) succeeds this PR can be approved and merged without further review. 
