### PR TITLE
[AUTO] update cube_preprocessing

### DIFF
--- a/data/interim/alien_taxa_without_occs.tsv
+++ b/data/interim/alien_taxa_without_occs.tsv
@@ -21,7 +21,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 182134454	1195013	Otiorhynchus aurifer	1999	2018	Insecta	Animalia
 152544520	1319260	Tetraponera allaborans	1980	2018	Insecta	Animalia
 152544508	1321805	Pheidole bilimeki	1911	2018	Insecta	Animalia
-152544494	1325561	Paratrechina longicornis	1980	2018	Insecta	Animalia
 213213874	1349836	Hylaeus absolutus	2021	2021	Insecta	Animalia
 152544459	1419894	Euborellia annulipes	2016	2018	Insecta	Animalia
 152544422	1420197	Aleurodothrips fasciapennis	2018	2018	Insecta	Animalia
@@ -756,7 +755,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 182133725	8782549	Anolis	2018	2018	Squamata	Animalia
 213213511	8791507	Physalis philadelphica	2008	2017	Magnoliopsida	Plantae
 213213618	8864505	Macomopsis melo	2021	2021	Bivalvia	Animalia
-213213012	8918909	Bromus hordeaceus divaricatus	1857	1870	Liliopsida	Plantae
 182133699	8953936	Caiman crocodilus	2017	2017	Crocodylia	Animalia
 213212580	8991514	Caracara plancus cheriway	NA	NA	Aves	Animalia
 182133741	9022569	Chrysopelea ornata	2014	2014	Squamata	Animalia


### PR DESCRIPTION
## Brief description

This is an **automatically generated PR**. 
The following steps are all automatically performed:

- rerun occurrence_indicators_preprocessing to create and upload 
`df_timeseries.rData` to the UAT bucket.
- `df_timeseries.rData` is combined with `grid.RData` from the UAT bucket using 
`alienSpecies::createTimeseries()`. The result is also stored on the UAT bucket.

Note to the reviewer: the workflow automation is still in a development phase. 
Please, check the output thoroughly before merging to `main`. 
run_occurrence_indicators_preprocessing.r downloads 
`./data/interim/intersect_EEA_ref_grid_protected_areas.tsv` from 
`trias-project/indicators` then it runs 
`./src/05_occurrence_indicators_preprocessing.Rmd` based on the script from [trias-project/indicators/](https://github.com/trias-project/indicators/blob/main/src/05_occurrence_indicators_preprocessing.Rmd).