### PR TITLE
add vernacular_name to translate_simple

### DIFF
--- a/data/output/UAT_direct/translations_simple.csv
+++ b/data/output/UAT_direct/translations_simple.csv
@@ -281,3 +281,4 @@
 "key";;;"Key"
 "undefined";;;"Undefined"
 "cumulative";"cumulatief aantal";"nombre cumulé";"cumulative number"
+"vernacular_name";"zoeken op gangbare namen";"recherche par noms communs";"search by common names"


### PR DESCRIPTION
Since we are going to make this a checkbox which switches from searching by latin names (taxonomic hierarchy) to searching by common names (see https://github.com/inbo/alien-species-portal/issues/129) i've added some translations to this effect.

@soriadelva do you agree with these translations ? 

fixes #348 