### PR TITLE
[AUTO] update cube_preprocessing

### DIFF
--- a/data/interim/alien_taxa_without_occs.tsv
+++ b/data/interim/alien_taxa_without_occs.tsv
@@ -24,7 +24,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213213874	1349836	Hylaeus absolutus	2021	2021	Insecta	Animalia
 152544459	1419894	Euborellia annulipes	2016	2018	Insecta	Animalia
 152544422	1420197	Aleurodothrips fasciapennis	2018	2018	Insecta	Animalia
-152544448	1420612	Scirtothrips longipennis	2018	2018	Insecta	Animalia
 152544453	1420765	Chaetanaphothrips orchidii	2018	2018	Insecta	Animalia
 152544436	1420769	Aurantothrips orchidaceus	2018	2018	Insecta	Animalia
 152544438	1420791	Leucothrips nigripennis	2018	2018	Insecta	Animalia
@@ -34,11 +33,10 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152544412	1422818	Pseudagrion microcephalum	2011	2012	Insecta	Animalia
 182134330	1548900	Dohrniphora cornuta	2005	2005	Insecta	Animalia
 213214411	1623077	Tephritis carmen	1979	1979	Insecta	Animalia
+152544359	1722140	Eumodicogryllus bordigalensis	2018	2018	Insecta	Animalia
 213214010	1835422	Schiffermuelleria bruandella	2016	2016	Insecta	Animalia
 213214212	2012520	Agonoscena succincta	2021	2021	Insecta	Animalia
-213214088	2088481	Unaspis euonymi	2016	2021	Insecta	Animalia
 159748106	2114326	Eurytemora americana	NA	NA	Copepoda	Animalia
-182134126	2114769	Pseudodiaptomus marinus	2015	2015	Copepoda	Animalia
 159748091	2115724	Balanus trigonus	NA	NA	Maxillopoda	Animalia
 152544238	2138649	Mermessus denticulatus	1997	1997	Arachnida	Animalia
 152544229	2140406	Triaeris stenaspis	2018	2018	Arachnida	Animalia
@@ -77,7 +75,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 159747996	2228667	Sinelobus stanfordi	NA	NA	Malacostraca	Animalia
 152543820	2284443	Mastophorus	2004	2011	Chromadorea	Animalia
 152543744	2286079	Crassostrea virginica	1960	2017	Bivalvia	Animalia
-152543768	2288847	Teredo navalis	1730	1732	Bivalvia	Animalia
 152543766	2288859	Psiloteredo megotara	1600	2016	Bivalvia	Animalia
 156872873	2292567	Cipangopaludina chinensis	2016	2021	Gastropoda	Animalia
 157092291	2294131	Allopeas clavulinum	2003	2003	Gastropoda	Animalia
@@ -177,13 +174,10 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213212273	2514552	Puccinia smyrnii	NA	NA	Pucciniomycetes	Fungi
 213212284	2514574	Puccinia subnitens	NA	NA	Pucciniomycetes	Fungi
 152543187	2514966	Puccinia sorghi	1997	1997	Pucciniomycetes	Fungi
-152543185	2514972	Puccinia komarovii	2009	2009	Pucciniomycetes	Fungi
-152543183	2515236	Puccinia antirrhini	1947	1947	Pucciniomycetes	Fungi
 213212264	2515591	Uromyces dianthi	NA	NA	Pucciniomycetes	Fungi
 213212268	2515673	Uromyces hedysari-obscuri	NA	NA	Pucciniomycetes	Fungi
 213212261	2515982	Uromyces croci	1876	1876	Pucciniomycetes	Fungi
 152543166	2516117	Gymnosporangium confusum	1879	1882	Pucciniomycetes	Fungi
-152543157	2516419	Tranzschelia discolor	2000	2005	Pucciniomycetes	Fungi
 152543128	2557730	Sporisorium destruens	1899	2018	Ustilaginomycetes	Fungi
 152543209	2627503	Batrachochytrium dendrobatidis	2018	2018	Rhizophydiomycetes	Fungi
 213213353	2653389	Ephedra gerardiana	1999	2021	Gnetopsida	Plantae
@@ -197,6 +191,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213212831	2703867	Leptochloa decipiens	1911	1921	Liliopsida	Plantae
 152546982	2704112	Bothriochloa decipiens	1947	1947	Liliopsida	Plantae
 152546969	2704234	Poa alpina	1850	1850	Liliopsida	Plantae
+152546974	2704341	Schismus barbatus	1836	2010	Liliopsida	Plantae
 152547088	2704664	Eremopyrum bonaepartis	1954	1954	Liliopsida	Plantae
 152547097	2705066	Panicum hirticaule	1969	1969	Liliopsida	Plantae
 152547098	2705092	Panicum coloratum	1901	1986	Liliopsida	Plantae
@@ -220,11 +215,12 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152546724	2764337	Commelina obliqua	1999	2000	Liliopsida	Plantae
 152546634	2784401	Traunsteinera globosa	1812	1812	Liliopsida	Plantae
 213212557	2805420	Spiranthes cernua	2021	2021	Liliopsida	Plantae
+213212605	2870049	Pinellia tripartita	2017	2020	Liliopsida	Plantae
+213212609	2871376	Spirodela punctata	2015	2016	Liliopsida	Plantae
 152546215	2874019	Aristolochia rotunda	1952	1952	Magnoliopsida	Plantae
 152546098	2874701	Tamarix canariensis	1946	1946	Magnoliopsida	Plantae
 213215616	2874718	Begonia semperflorens	2005	2016	Magnoliopsida	Plantae
 152545865	2888298	Moneses uniflora	1850	1949	Magnoliopsida	Plantae
-152546272	2888588	Viburnum rhytidophylloides	2013	2018	Magnoliopsida	Plantae
 213215410	2888796	Cephalaria syriaca	1891	2011	Magnoliopsida	Plantae
 213215401	2888799	Cephalaria alpina	1970	1970	Magnoliopsida	Plantae
 213215392	2888805	Scabiosa atropurpurea	1835	2018	Magnoliopsida	Plantae
@@ -233,14 +229,15 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152546146	2889024	Rumex confusus	2011	2017	Magnoliopsida	Plantae
 152546147	2889030	Rumex altissimus	1903	1909	Magnoliopsida	Plantae
 213214009	2891621	Erodium malacoides	2008	2021	Magnoliopsida	Plantae
+152545265	2908428	Galium divaricatum	1900	2008	Magnoliopsida	Plantae
 152545795	2925492	Verbena supina	1947	1947	Magnoliopsida	Plantae
 152545798	2925515	Verbena halei	1921	1940	Magnoliopsida	Plantae
-152545799	2925518	Verbena brasiliensis	1993	1993	Magnoliopsida	Plantae
 152545539	2925754	Lappula marginata	1880	1896	Magnoliopsida	Plantae
 152545543	2925790	Heliotropium amplexicaule	1890	1890	Magnoliopsida	Plantae
 152545522	2926041	Nonea rosea	1828	1828	Magnoliopsida	Plantae
 213215471	2927029	Salvia splendens	2008	2021	Magnoliopsida	Plantae
 152545768	2927030	Salvia aethiopis	1835	1910	Magnoliopsida	Plantae
+152545756	2927224	Dracocephalum thymiflorum	1893	2017	Magnoliopsida	Plantae
 152545753	2927296	Stachys cretica	1872	1942	Magnoliopsida	Plantae
 152545021	2927522	Cuscuta planiflora	1895	1895	Magnoliopsida	Plantae
 152545482	2928153	Phacelia purshii	1893	1893	Magnoliopsida	Plantae
@@ -270,7 +267,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545427	3045193	Alyssum strigosum	1909	1909	Magnoliopsida	Plantae
 152545417	3046778	Sisymbrium septulatum	1954	1954	Magnoliopsida	Plantae
 152545415	3046839	Sisymbrium runcinatum	2004	2004	Magnoliopsida	Plantae
-152545414	3046850	Sisymbrium strictissimum	1857	2018	Magnoliopsida	Plantae
 213214647	3047147	Neslia paniculata thracica	1866	1927	Magnoliopsida	Plantae
 213214628	3048073	Erysimum collisparsum	1893	1941	Magnoliopsida	Plantae
 152545461	3048288	Erysimum diffusum	1877	1896	Magnoliopsida	Plantae
@@ -278,7 +274,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545439	3053950	Enarthrocarpus lyratus	1892	1893	Magnoliopsida	Plantae
 152546431	3056259	Acalypha indica	2003	2003	Magnoliopsida	Plantae
 152546433	3060710	Manihot grahamii	2017	2017	Magnoliopsida	Plantae
-152546443	3066482	Euphorbia peplis	1878	1878	Magnoliopsida	Plantae
+152546449	3067869	Euphorbia chamaesyce	2000	2000	Magnoliopsida	Plantae
 152546454	3070346	Euphorbia nutans	1995	1995	Magnoliopsida	Plantae
 152545960	3083603	Polycnemum arvense	1835	1903	Magnoliopsida	Plantae
 152545964	3083657	Atriplex oblongifolia	1850	1850	Magnoliopsida	Plantae
@@ -287,6 +283,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545985	3083921	Chenopodium pratericola	1893	1953	Magnoliopsida	Plantae
 152546002	3084616	Glinus lotoides	1911	1911	Magnoliopsida	Plantae
 213214852	3084748	Claytonia perfoliata	1859	2020	Magnoliopsida	Plantae
+182135028	3084872	Drosanthemum floribundum	2018	2018	Magnoliopsida	Plantae
 152545994	3084922	Alternanthera paronychioides	1911	1911	Magnoliopsida	Plantae
 152545996	3084949	Alternanthera pungens	1949	1949	Magnoliopsida	Plantae
 152545997	3084958	Alternanthera caracasana	1947	1948	Magnoliopsida	Plantae
@@ -294,6 +291,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152546087	3085435	Cerastium dichotomum	1954	1955	Magnoliopsida	Plantae
 152544404	3088652	Guizotia schimperi	2015	2015	Magnoliopsida	Plantae
 213215227	3089142	Xanthium albinum	2020	2020	Magnoliopsida	Plantae
+213215103	3092083	Coleostephus myconis	2014	2014	Magnoliopsida	Plantae
 152544419	3092125	Acmella	1955	1955	Magnoliopsida	Plantae
 152544368	3092604	Leysera tenella	1911	1911	Magnoliopsida	Plantae
 152544355	3093891	Hypochaeris microcephala	1895	1895	Magnoliopsida	Plantae
@@ -319,13 +317,13 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152544073	3125765	Stuartina muelleri	1906	1914	Magnoliopsida	Plantae
 152544065	3125944	Santolina rosmarinifolia	1912	1912	Magnoliopsida	Plantae
 152544062	3126046	Erigeron pampeanus	1911	1911	Magnoliopsida	Plantae
-152543976	3127613	Centaurea paniculata	1895	1895	Magnoliopsida	Plantae
 152543970	3128007	Centaurea orientalis	1893	1894	Magnoliopsida	Plantae
 152543969	3128437	Centaurea glaberrima	1850	1850	Magnoliopsida	Plantae
 213215214	3132567	Galinsoga quadriradiata	1981	2022	Magnoliopsida	Plantae
 152543997	3133702	Adenostyles alliariae	1971	1971	Magnoliopsida	Plantae
 152543990	3137629	Rhodanthe floribunda	1894	1894	Magnoliopsida	Plantae
 159748874	3137686	Rhodanthe stricta	1891	1891	Magnoliopsida	Plantae
+213215231	3138949	Melampodium divaricatum	2010	2010	Magnoliopsida	Plantae
 152543898	3140910	Madia sativa	1941	1941	Magnoliopsida	Plantae
 152543930	3141571	Mantisalca salmantica	1877	1890	Magnoliopsida	Plantae
 152543935	3142974	Doronicum excelsum	1867	2020	Magnoliopsida	Plantae
@@ -357,7 +355,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213213226	3746867	Cheilanthes viridis macrophylla	2005	2005	Polypodiopsida	Plantae
 152544691	3754353	Saxifraga urbium	1908	2014	Magnoliopsida	Plantae
 213214932	3755928	Chenopodium album missouriense	2003	2003	Magnoliopsida	Plantae
-152545982	3756650	Chenopodium reynieri	2015	2017	Magnoliopsida	Plantae
 213214934	3757050	Chenopodium berlandieri bushianum	1952	1952	Magnoliopsida	Plantae
 152545981	3757189	Chenopodium auricomiforme	1911	1911	Magnoliopsida	Plantae
 159749099	3757457	Chenopodium polygonoides	1951	1951	Magnoliopsida	Plantae
@@ -368,17 +365,17 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545736	3895710	Teucrium lucidrys	2011	2018	Magnoliopsida	Plantae
 213215469	3898065	Salvia lavandulifolia gallica	1900	1900	Magnoliopsida	Plantae
 152545743	3905970	Marrubium peregrinum	1835	1912	Magnoliopsida	Plantae
-152546332	3927790	Ranunculus gramineus	1850	1850	Magnoliopsida	Plantae
 152546234	3937506	Corynabutilon suntense	2006	2006	Magnoliopsida	Plantae
 213214346	3982013	Epimedium pubigerum	2020	2020	Magnoliopsida	Plantae
 213214366	3982284	Mahonia wagneri	2010	2020	Magnoliopsida	Plantae
 152543401	3989886	Lythrum acutangulum	1874	1989	Magnoliopsida	Plantae
 152545821	4007682	Lysimachia linum-stellatum	1858	1858	Magnoliopsida	Plantae
+213214842	4022910	Portulaca macrantha	1948	2013	Magnoliopsida	Plantae
+152546009	4023424	Portulaca trituberculata	1865	2011	Magnoliopsida	Plantae
 152545611	4055853	Buddleja albiflora	1945	1945	Magnoliopsida	Plantae
 152545529	4064572	Cynoglossum clandestinum	1948	1948	Magnoliopsida	Plantae
 152546297	4095186	Valeriana pyrenaica	1957	1957	Magnoliopsida	Plantae
 152546305	4095244	Valerianella vesicaria	1850	1850	Magnoliopsida	Plantae
-152546294	4102909	Lomelosia stellata	2017	2017	Magnoliopsida	Plantae
 213215383	4103685	Scabiosa nitens	2016	2021	Magnoliopsida	Plantae
 213212695	4104665	Avellinia festucoides	1986	1986	Liliopsida	Plantae
 152546944	4104890	Austrostipa scabra falcata	1896	1896	Liliopsida	Plantae
@@ -399,8 +396,8 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152547104	4123970	Festuca gautieri	1991	1991	Liliopsida	Plantae
 152547113	4126800	Aristida hordeacea	1884	1884	Liliopsida	Plantae
 152546921	4127831	Stipa pennata	1824	1892	Liliopsida	Plantae
-152546948	4128347	Bromus intermedius	1952	1952	Liliopsida	Plantae
 152547114	4128792	Aristida congesta	1947	1950	Liliopsida	Plantae
+213213046	4132010	Pleioblastus distichus	2018	2018	Liliopsida	Plantae
 213212834	4132112	Leptochloa panicea brachiata	1900	1947	Liliopsida	Plantae
 213213048	4132188	Pleioblastus argenteostriatus	2011	2011	Liliopsida	Plantae
 213212833	4132902	Leptochloa decipiens peacockii	1911	1947	Liliopsida	Plantae
@@ -450,7 +447,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152544272	4487282	Fulvius anthocoroides	2008	2018	Insecta	Animalia
 213214116	4487660	Dichrooscytus gustavi	2020	2020	Insecta	Animalia
 182134272	4528099	Tuta absoluta	2011	2021	Insecta	Animalia
-213214809	4544661	Aceria ilicis	2015	2022	Arachnida	Animalia
 213214815	4544759	Aceria heteronyx	2012	2022	Arachnida	Animalia
 213214832	4549071	Varroa jacobsoni	1985	2018	Arachnida	Animalia
 152543814	4556286	Meloidogyne artiellia	2011	2018	Chromadorea	Animalia
@@ -492,11 +488,9 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 182133718	5225433	Trachylepis striata	2018	2019	Squamata	Animalia
 182133781	5225659	Morelia spilota	2013	2019	Squamata	Animalia
 182133795	5226308	Agama agama	2015	2020	Squamata	Animalia
-159747373	5229045	Psittacula alexandri	2014	2016	Aves	Animalia
 159747376	5229072	Psittacula derbiana	2016	2016	Aves	Animalia
 213212319	5240299	Amanita inopinata	2008	2018	Agaricomycetes	Fungi
 182132859	5241445	Volvariella volvacea	2018	2018	Agaricomycetes	Fungi
-152543115	5250069	Thecaphora oxalidis	2014	2018	Ustilaginomycetes	Fungi
 152543121	5250090	Urocystis trollii	1894	2018	Ustilaginomycetes	Fungi
 182132946	5270720	Chara braunii	1864	2018	Charophyceae	Plantae
 152547227	5274858	Salvinia natans	1835	1889	Polypodiopsida	Plantae
@@ -504,7 +498,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152546737	5289490	Typha provincialis	2012	2020	Liliopsida	Plantae
 213212856	5289726	Cenchrus spinifex	1960	1960	Liliopsida	Plantae
 152546828	5289751	Phalaris coerulescens	1950	1950	Liliopsida	Plantae
-152546808	5289781	Aegilops geniculata	1854	1973	Liliopsida	Plantae
 152546806	5289791	Aegilops ventricosa	1835	1892	Liliopsida	Plantae
 152546807	5289793	Aegilops triuncialis	1854	1946	Liliopsida	Plantae
 152546848	5290129	Tragus berteronianus	1947	1948	Liliopsida	Plantae
@@ -524,7 +517,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545083	5358301	Scorpiurus vermiculatus	1957	1957	Magnoliopsida	Plantae
 152545060	5359118	Trifolium retusum	1835	1937	Magnoliopsida	Plantae
 152545070	5359263	Trifolium spumosum	1954	1955	Magnoliopsida	Plantae
-152545081	5359526	Trifolium purpureum	1876	1877	Magnoliopsida	Plantae
 213213843	5360221	Thermopsis montana	2015	2018	Magnoliopsida	Plantae
 152545127	5360415	Trigonella calliceras	1948	1948	Magnoliopsida	Plantae
 152545120	5360451	Trigonella esculenta	2003	2004	Magnoliopsida	Plantae
@@ -548,6 +540,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152546040	5384465	Gypsophila scorzonerifolia	1866	1956	Magnoliopsida	Plantae
 213215000	5384782	Silene csereii	1908	1908	Magnoliopsida	Plantae
 152543611	5386028	Cyanus triumfettii	1911	1911	Magnoliopsida	Plantae
+152544421	5386764	Acmella oleracea	2008	2008	Magnoliopsida	Plantae
 213215159	5387537	Aster indamellus	2016	2016	Magnoliopsida	Plantae
 152543776	5401239	Felicia tenella	1911	1911	Magnoliopsida	Plantae
 152543779	5401508	Emilia fosbergii	1997	1997	Magnoliopsida	Plantae
@@ -557,7 +550,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152545242	5414545	Periploca graeca	1918	1918	Magnoliopsida	Plantae
 152545244	5414550	Vincetoxicum rossicum	1965	1965	Magnoliopsida	Plantae
 213215540	5414989	Digitalis lanata	2020	2020	Magnoliopsida	Plantae
-152545655	5415014	Linaria angustissima	1835	1835	Magnoliopsida	Plantae
 159746847	5421557	Coscinodiscus wailesii	1997	1997	Bacillariophyceae	Chromista
 213215309	5539680	Pimpinella aromatica	2004	2011	Magnoliopsida	Plantae
 152543418	5544928	Clarkia purpurea quadrivulnera	1894	1894	Magnoliopsida	Plantae
@@ -577,7 +569,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 182134198	5632022	Lotus dorycnium	1903	1903	Magnoliopsida	Plantae
 152545119	5632334	Trigonella hierosolymitana	1886	1901	Magnoliopsida	Plantae
 152546420	5646136	Elatine alsinastrum	1860	1863	Magnoliopsida	Plantae
-152546110	5652131	Polygonum aviculare rurivagum	2010	2010	Magnoliopsida	Plantae
 152545829	5659657	Gilia capitata mediomontana	1893	1898	Magnoliopsida	Plantae
 152546865	5674047	Nassella hyalina	1897	1897	Liliopsida	Plantae
 152546832	5674218	Setaria dielsii	1947	1947	Liliopsida	Plantae
@@ -585,7 +576,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213213669	5688347	Sedum sediforme	2013	2020	Magnoliopsida	Plantae
 152543786	5704991	Helenium clementii	1972	1972	Magnoliopsida	Plantae
 213213014	5739284	Porphyrio poliocephalus	1982	1998	Aves	Animalia
-152543101	5740285	Gyrodactylus proterorhini	2011	2018	Monogenea	Animalia
 159747121	5788513	Spizaetus melanoleucus	2017	2017	Aves	Animalia
 213213497	5795017	Ferussacia folliculum	1866	2015	Gastropoda	Animalia
 152544614	5831906	Bupleurum gerardi	1886	2010	Magnoliopsida	Plantae
@@ -596,7 +586,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152544617	6026972	Bupleurum praealtum	1835	1892	Magnoliopsida	Plantae
 152545980	6035549	Chenopodium striatiforme	1862	1967	Magnoliopsida	Plantae
 213215184	6076279	Centaurea diluta algeriensis	1918	1918	Magnoliopsida	Plantae
-159747203	6101013	Chloris spinoides	2003	2003	Aves	Animalia
 182133220	6101215	Leptoptilos crumenifer	NA	NA	Aves	Animalia
 152544011	6128436	Amphibalanus reticulatus	1997	2016	Maxillopoda	Animalia
 213212495	6159238	Lacerta strigata	2021	2021	Squamata	Animalia
@@ -612,7 +601,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213213344	6476579	Dolichoplana signata	2018	2018	NA	Animalia
 213215299	6550056	Daucus carota sativus	2018	2018	Magnoliopsida	Plantae
 159747368	6559940	Helictochloa bromoides	1950	1950	Liliopsida	Plantae
-213214891	6709291	Reynoutria compacta	1981	2020	Magnoliopsida	Plantae
 152546942	6710856	Austrostipa scabra scabra	1897	1939	Liliopsida	Plantae
 213214813	6913023	Aceria brachytarsus	2014	2021	Arachnida	Animalia
 213214803	6913500	Eriophyes alniincanae	2013	2018	Arachnida	Animalia
@@ -633,7 +621,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 152543162	7239373	Uromyces veratri	1852	1852	Pucciniomycetes	Fungi
 213212265	7239389	Uromyces proeminens	NA	NA	Pucciniomycetes	Fungi
 213212211	7261816	Eptesicus nilssonii	2016	2016	Mammalia	Animalia
-213214764	7266329	Salix alba alba	2018	2018	Magnoliopsida	Plantae
 213214759	7266656	Salix rorida	2011	2021	Magnoliopsida	Plantae
 152545803	7270761	Actinidia deliciosa	2000	2020	Magnoliopsida	Plantae
 213215722	7272185	Rosa carolina carolina	2011	2021	Magnoliopsida	Plantae
@@ -654,7 +641,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213215552	7332416	Chaenorhinum origanifolium origanifolium	2001	2018	Magnoliopsida	Plantae
 213215431	7332517	Orobanche flava flava	1944	1945	Magnoliopsida	Plantae
 152545687	7333212	Antirrhinum graniticum	1975	1975	Magnoliopsida	Plantae
-152545637	7333320	Ellisiophyllum pinnatum	2016	2016	Magnoliopsida	Plantae
 152544723	7334576	Sempervivum barbulatum	2009	2018	Magnoliopsida	Plantae
 159747187	7340811	Euplectes macroura	2010	2010	Aves	Animalia
 152545620	7353862	Verbascum divaricatum	1954	1954	Magnoliopsida	Plantae
@@ -721,7 +707,6 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213213449	8045384	Granaria frumentum	1924	1924	Gastropoda	Animalia
 152547082	8047362	Sporobolus creber	1911	1911	Liliopsida	Plantae
 159747067	8050384	Bonamia ostreae	1980	1980	Haplosporea	Protozoa
-152543324	8077391	Citrus aurantium	1949	1949	Magnoliopsida	Plantae
 159748820	8078031	Artemisia afra	1893	1900	Magnoliopsida	Plantae
 213212612	8082581	Synoicus chinensis	2001	2001	Aves	Animalia
 213212852	8112114	Elymus hystrix	1891	1891	Liliopsida	Plantae
@@ -731,6 +716,7 @@ key	nubKey	canonicalName	first_observed	last_observed	class	kingdom
 213212556	8219807	Trimeresurus albolabris	2021	2021	Squamata	Animalia
 152545492	8227753	Anchusa procera	1904	2020	Magnoliopsida	Plantae
 213212549	8228334	Daboia palaestinae	2022	2022	Squamata	Animalia
+152547195	8241853	Anisocampium niponicum	2017	2017	Polypodiopsida	Plantae
 152545903	8243150	Spirobassia hirsuta	1850	1850	Magnoliopsida	Plantae
 213213853	8261015	Trigonella foenum-graecum	2015	2021	Magnoliopsida	Plantae
 213214700	8264893	Nephilingis cruentata	1986	1986	Arachnida	Animalia

--- a/data/interim/taxa_last_observed_in_BE_before_1950.tsv
+++ b/data/interim/taxa_last_observed_in_BE_before_1950.tsv
@@ -22,11 +22,11 @@ taxonKey	canonicalName	first_observed	last_observed	class	kingdom	kingdomKey	cla
 6366597	Gentiana acaulis	1844	1911	Magnoliopsida	Plantae	6	220
 5374998	Arabis collina	1850	1949	Magnoliopsida	Plantae	6	220
 5376785	Lepidium fasciculatum	1889	1901	Magnoliopsida	Plantae	6	220
+3042399	Camelina alyssum	1813	1946	Magnoliopsida	Plantae	6	220
 3042439	Camelina rumelica	1893	1912	Magnoliopsida	Plantae	6	220
 3045042	Alyssum simplex	1850	1924	Magnoliopsida	Plantae	6	220
 2925879	Amsinckia eastwoodiae	1924	1924	Magnoliopsida	Plantae	6	220
 3741432	Verbascum banaticum	1908	1908	Magnoliopsida	Plantae	6	220
-5415013	Linaria genistifolia	1891	1947	Magnoliopsida	Plantae	6	220
 7303024	Plantago myosuros	1895	1948	Magnoliopsida	Plantae	6	220
 7308043	Lamium garganicum garganicum	1906	1920	Magnoliopsida	Plantae	6	220
 3885185	Stachys atherocalyx	1922	1922	Magnoliopsida	Plantae	6	220
@@ -99,7 +99,7 @@ taxonKey	canonicalName	first_observed	last_observed	class	kingdom	kingdomKey	cla
 10773250	Melilotus siculus	1948	1948	Magnoliopsida	Plantae	6	220
 5349991	Coronilla securidaca	1909	1909	Magnoliopsida	Plantae	6	220
 2965250	Medicago tornata	1949	1949	Magnoliopsida	Plantae	6	220
-3053399	Rorippa pyrenaica	1854	1939	Magnoliopsida	Plantae	6	220
 7711892	Isatis quadrialata	1909	1932	Magnoliopsida	Plantae	6	220
+3137579	Galactites tomentosa	1912	1923	Magnoliopsida	Plantae	6	220
 3089549	Centaurea depressa	1909	1922	Magnoliopsida	Plantae	6	220
 3026426	Spiraea brachybotrys	1947	1947	Magnoliopsida	Plantae	6	220


### PR DESCRIPTION
## Brief description

This is an **automatically generated PR**. 
The following steps are all automatically performed:

- rerun occurrence_indicators_preprocessing to create and upload 
`df_timeseries.rData` to the UAT bucket.
- `df_timeseries.rData` is combined with `grid.RData` from the UAT bucket using 
`alienSpecies::createTimeseries()`. The result is also stored on the UAT bucket.

Note to the reviewer: the workflow automation is still in a development phase. 
Please, check the output thoroughly before merging to `main`. 
run_occurrence_indicators_preprocessing.r downloads 
`./data/interim/intersect_EEA_ref_grid_protected_areas.tsv` from 
`trias-project/indicators` then it runs 
`./src/05_occurrence_indicators_preprocessing.Rmd` based on the script from [trias-project/indicators/](https://github.com/trias-project/indicators/blob/main/src/05_occurrence_indicators_preprocessing.Rmd).