### PR TITLE
add concurrency to upload_files_processing

### DIFF
--- a/.github/workflows/upload_files_processing.yaml
+++ b/.github/workflows/upload_files_processing.yaml
@@ -8,6 +8,10 @@ on:
 
 name: upload_files_processing
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}  # Use the event name, branch reference, and workflow name as the concurrency group
+  cancel-in-progress: true    # Cancel any in-progress runs in the same group
+
 jobs:
   upload_files:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
This logic cancels other github actions run from the same branch/pull request