### PR TITLE
fix #567 Reformulate early warning as early alert

### DIFF
--- a/data/output/UAT_direct/translations_simple.csv
+++ b/data/output/UAT_direct/translations_simple.csv
@@ -28,7 +28,7 @@
 "start";"Start";"Démarrage";"Start"
 "checklist_indicators";"Checklist indicatoren";"Indicateurs checklist";"Checklist indicators"
 "species_information";"Soortgegevens";"Données d'espèces";"Species information"
-"early_warning";"Vroege detectie";"Détection précoce";"Early warning"
+"early_warning";"Early alert";"Early alert";"Early alert"
 "management";"Beheer";"Gestion";"Management"
 "taxa";"Taxa";"Taxa";"Taxa"
 "trend";"Trend";"Tendance";"Trend"


### PR DESCRIPTION
The text in tile Early warning has been reformulated to Early alert (NL, EN, en FR)