### PR TITLE
fix #487

### DIFF
--- a/src/install_packages_occ_indic.R
+++ b/src/install_packages_occ_indic.R
@@ -6,3 +6,13 @@ required <- c("devtools", "knitr", "dplyr", "magrittr", "rgbif", "tidylog",
 if (!all(required %in% installed)) {
   install.packages(required[!required %in% installed])
 }
+
+# Test if minimum version of aws.s3 is installed
+if (packageVersion("aws.s3") < "0.3.22") {
+  install.packages("devtools")
+  cat("aws.s3 version:", paste(unlist(packageVersion("aws.s3")), collapse = "."), "\n
+      ==> installing v0.3.22 from https://rforge.net")
+  devtools::install_version("aws.s3", version = "0.3.22", repos = "https://rforge.net")
+}else{
+  cat("aws.s3 version:", paste(unlist(packageVersion("aws.s3")), collapse = "."), "\n")
+}


### PR DESCRIPTION
This pull request adds functionality to ensure that a minimum version of the `aws.s3` package is installed. If the installed version is below `0.3.22`, the script installs the required version from a specified repository.

### Key Changes:

#### Package Installation Enhancements:
* Added a check for the `aws.s3` package version. If the installed version is below `0.3.22`, the script installs the required version (`0.3.22`) using the `devtools::install_version` function from the `https://rforge.net` repository.
* Included logging to display the current `aws.s3` version before and after the installation process.