### PR TITLE
add concurrency to translation test

### DIFF
--- a/.github/workflows/run_translations_test.yaml
+++ b/.github/workflows/run_translations_test.yaml
@@ -7,6 +7,10 @@ on:
       - 'data/output/UAT_processing/**'
       - 'data/output/UAT_direct/**'
 
+concurrency:
+  group: translations-test-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 name: run_translations_test
 
 jobs:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for running translation tests by introducing concurrency controls. This helps prevent overlapping runs and ensures that only the latest workflow execution for a given branch or pull request is active.

Workflow improvements:

* Added a `concurrency` group to the `.github/workflows/run_translations_test.yaml` workflow, using the branch or ref name to group runs and enabling `cancel-in-progress` to automatically cancel any in-progress runs for the same group.