### PR TITLE
512 fix issue with commit and push changes

### DIFF
--- a/.github/workflows/cube_preprocessing.yaml
+++ b/.github/workflows/cube_preprocessing.yaml
@@ -118,7 +118,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.3
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/cube_preprocessing.yaml
+++ b/.github/workflows/cube_preprocessing.yaml
@@ -118,7 +118,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.3
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/get_griis_checklist.yaml
+++ b/.github/workflows/get_griis_checklist.yaml
@@ -91,7 +91,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
     
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/get_muskrat_data.yaml
+++ b/.github/workflows/get_muskrat_data.yaml
@@ -59,7 +59,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.3
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/get_muskrat_data.yaml
+++ b/.github/workflows/get_muskrat_data.yaml
@@ -59,7 +59,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.3
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/get_oxyura_jamaicensis_management.yaml
+++ b/.github/workflows/get_oxyura_jamaicensis_management.yaml
@@ -60,7 +60,7 @@ jobs:
         shell: Rscript {0}
     
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/management-prep.yaml
+++ b/.github/workflows/management-prep.yaml
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/update_Xenopus_laevis_management.yaml
+++ b/.github/workflows/update_Xenopus_laevis_management.yaml
@@ -57,7 +57,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/update_eu_concern_list.yaml
+++ b/.github/workflows/update_eu_concern_list.yaml
@@ -84,7 +84,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/update_trendOccupancy.yaml
+++ b/.github/workflows/update_trendOccupancy.yaml
@@ -93,7 +93,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a specific version (`v0.11.1`) of the `devops-infra/action-commit-push` action instead of the `master` branch. This change ensures more stability and predictability in automated commit and push steps across multiple workflow files.

Version pinning for workflow actions:

* Updated the `uses` field for `devops-infra/action-commit-push` from `master` to `v0.11.1` in the following workflow files to ensure consistent and reliable action behavior:
  * `.github/workflows/cube_preprocessing.yaml`
  * `.github/workflows/get_griis_checklist.yaml`
  * `.github/workflows/get_muskrat_data.yaml`
  * `.github/workflows/get_oxyura_jamaicensis_management.yaml`
  * `.github/workflows/management-prep.yaml`
  * `.github/workflows/update_Xenopus_laevis_management.yaml`
  * `.github/workflows/update_eu_concern_list.yaml`
  * `.github/workflows/update_trendOccupancy.yaml`

The actions have been tested and they work! No in depth review needed!