### PR TITLE
Add additional reviewer to cube preprocessing workflow

### DIFF
--- a/.github/workflows/cube_preprocessing.yaml
+++ b/.github/workflows/cube_preprocessing.yaml
@@ -137,6 +137,6 @@ jobs:
           target_branch: uat
           title: "[AUTO] update cube_preprocessing"
           template: .github/PR_occ_indic_preprocessing.md
-          reviewer: SanderDevisscher
+          reviewer: SanderDevisscher,soriadelva
           label: automated workflow
           get_diff: false


### PR DESCRIPTION
This pull request makes a minor update to the automated workflow configuration by modifying the list of reviewers for pull requests generated by the cube preprocessing workflow.

* Added `soriadelva` as an additional reviewer alongside `SanderDevisscher` in the `.github/workflows/cube_preprocessing.yaml` workflow configuration.