### PR TITLE
603 bug update eu concern list

### DIFF
--- a/.github/workflows/update_eu_concern_list.yaml
+++ b/.github/workflows/update_eu_concern_list.yaml
@@ -44,10 +44,6 @@ jobs:
           sudo apt install libudunits2-dev
           sudo apt install --yes libharfbuzz-dev libfribidi-dev
           sudo apt-get install -y libfontconfig1-dev
-          R --no-save -e 'install.packages("devtools")'
-          R --no-save -e 'devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)'
-          R --no-save -e 'devtools::install_github("inbo/alien-species-portal@uat", 
-                         subdir = "alienSpecies", force = TRUE)'
 
       - name: Install R packages
         run: |

--- a/src/install_packages_eu_concern_list.R
+++ b/src/install_packages_eu_concern_list.R
@@ -3,7 +3,7 @@
 installed <- rownames(installed.packages())
 # specify packages we need
 required <- c("aws.s3", "magrittr", "readr",
-              "dplyr", "rgbif", "devtools", "leaflet.extras"
+              "dplyr", "rgbif", "devtools"
 )
 # install packages if needed
 if (!all(required %in% installed)) {
@@ -13,6 +13,7 @@ if (!all(required %in% installed)) {
 }
 
 # install non-CRAN packages ####
+devtools::install_github("trafficonese/leaflet.extras", force = TRUE)
 devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)
 devtools::install_github("inbo/alien-species-portal@uat", 
                          subdir = "alienSpecies", force = TRUE)

--- a/src/install_packages_eu_concern_list.R
+++ b/src/install_packages_eu_concern_list.R
@@ -1,8 +1,9 @@
+# install CRAN packages ####
 # get packages installed on machine
 installed <- rownames(installed.packages())
 # specify packages we need
 required <- c("aws.s3", "magrittr", "readr",
-              "dplyr", "rgbif"
+              "dplyr", "rgbif", "devtools", "leaflet.extras"
 )
 # install packages if needed
 if (!all(required %in% installed)) {
@@ -10,3 +11,8 @@ if (!all(required %in% installed)) {
   print(paste("Packages to install:", paste(pkgs_to_install, collapse = ", ")))
   install.packages(pkgs_to_install)
 }
+
+# install non-CRAN packages ####
+devtools::install_github("inbo/INBOtheme@v0.5.9", force = TRUE)
+devtools::install_github("inbo/alien-species-portal@uat", 
+                         subdir = "alienSpecies", force = TRUE)


### PR DESCRIPTION
This pull request refactors how R package dependencies are installed for the EU concern list workflow. The main change is moving the installation of both CRAN and non-CRAN R packages from the GitHub Actions workflow file into the dedicated R script, improving maintainability and clarity.

**Dependency installation refactor:**

* Moved installation of `devtools`, `INBOtheme`, and `alien-species-portal` from `.github/workflows/update_eu_concern_list.yaml` to `src/install_packages_eu_concern_list.R`, centralizing all R package installation logic in one place. [[1]](diffhunk://#diff-08a056a8c0ba907c297f5e974a12d0757e81b8dc9b9b8d1b68ca936e23278c66L47-L50) [[2]](diffhunk://#diff-b0dd79217be6b36374838fd86acc44c2dc7a3a05371d4bb8471c4a6469ef8914R1-R18)
* Added `leaflet.extras` and `devtools` to the required CRAN packages list in `src/install_packages_eu_concern_list.R` to ensure these dependencies are installed if missing.
* Ensured non-CRAN packages are installed using `devtools::install_github` within the R script for easier management and reproducibility.
