### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/copy_s3_uat_to_prod.yaml
+++ b/.github/workflows/copy_s3_uat_to_prod.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: PROD
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/cube_preprocessing.yaml
+++ b/.github/workflows/cube_preprocessing.yaml
@@ -39,19 +39,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Get latest successful run ID
         id: get-latest-run
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download be_alientaxa_cube artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: be_alientaxa_cube.csv
           path: ./cube_data/
@@ -85,7 +85,7 @@ jobs:
             libfontconfig1-dev
 
       - name: Cache R packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: r-cache
         with:
           path: ${{ env.R_LIBS_USER }}
@@ -100,7 +100,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -113,7 +113,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -122,7 +122,7 @@ jobs:
           add_timestamp: false
 
       - name: upload processed cube
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: be_alientaxa_cube_processed
           path: ./cube_data/be_alientaxa_cube_processed.csv
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
@@ -174,13 +174,13 @@ jobs:
           git pull origin automatic-update-occ_indic_preprocessing || echo "Nothing to pull."
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Get latest successful run ID
         id: get-latest-run
@@ -191,7 +191,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download be_classes_cube artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: be_classes_cube.csv
           path: ./cube_data/
@@ -200,7 +200,7 @@ jobs:
           merge-multiple: true
 
       - name: Download processed cube
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: be_alientaxa_cube_processed
           path: ./cube_data/
@@ -216,7 +216,7 @@ jobs:
           sudo apt install libuv1-dev
 
       - name: Cache R packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: r-cache
         with:
           path: ${{ env.R_LIBS_USER }}
@@ -231,7 +231,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -243,7 +243,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Upload cube artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "timeseries_${{ matrix.decade.start }}_${{ matrix.decade.end }}"
           path: "./cube_data/timeseries_${{ matrix.decade.start }}_${{ matrix.decade.end }}.csv"
@@ -270,23 +270,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: automatic-update-occ_indic_preprocessing
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: download rank cubes artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: timeseries_*
           merge-multiple: true
@@ -301,7 +301,7 @@ jobs:
           sudo apt install libuv1-dev
 
       - name: Cache R packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: r-cache
         with:
           path: ${{ env.R_LIBS_USER }}
@@ -316,7 +316,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -333,7 +333,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/delete_old_artifacts.yaml
+++ b/.github/workflows/delete_old_artifacts.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/get_griis_checklist.yaml
+++ b/.github/workflows/get_griis_checklist.yaml
@@ -32,19 +32,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -62,7 +62,7 @@ jobs:
         shell: Rscript {0}
         
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -75,7 +75,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
     
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -87,7 +87,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/get_muskrat_data.yaml
+++ b/.github/workflows/get_muskrat_data.yaml
@@ -27,19 +27,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -66,7 +66,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -78,7 +78,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/get_occ_cube.yaml
+++ b/.github/workflows/get_occ_cube.yaml
@@ -32,19 +32,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -66,7 +66,7 @@ jobs:
         shell: Rscript {0}
 
       - name: upload queries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: ./data/interim/cube_queries/*
           
@@ -93,19 +93,19 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -123,7 +123,7 @@ jobs:
         shell: Rscript {0}
         
       - name: download queries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with: 
           path: ./data/interim/cube_queries/
           merge-multiple: true #to make sure artifacts are downloaded into correct folder and not /artifact-name
@@ -133,13 +133,13 @@ jobs:
           Rscript -e "rmarkdown::render('src/get_cubes/download_cubes.Rmd', params = list(rank = '${{ matrix.param_value }}'), knit_root_dir = '../../')"
         
       - name: Upload cube artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.param_value == 'CLASS' && 'be_classes_cube_raw' || format('be_alientaxa_cube_{0}', matrix.param_value) }}
           path: ./cube_data/${{ matrix.param_value == 'CLASS' && 'be_classes_cube_raw' || format('be_alientaxa_cube_{0}', matrix.param_value) }}.csv
 
       - name: Upload cube metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: be_cube_metadata_${{ matrix.param_value }}
           path: ./cube_data/be_cube_metadata_${{ matrix.param_value }}.csv
@@ -169,19 +169,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -198,7 +198,7 @@ jobs:
         shell: Rscript {0}
         
       - name: download rank cubes artifacts 
-        uses: actions/download-artifact@v4 
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with: 
           pattern: be_alientaxa_cube_*
           merge-multiple: true
@@ -213,7 +213,7 @@ jobs:
         shell: Rscript {0}
         
       - name: upload occ cube
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: be_alientaxa_cube.csv
           path: ./cube_data/be_alientaxa_cube.csv
@@ -237,19 +237,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -266,7 +266,7 @@ jobs:
         shell: Rscript {0}
         
       - name: download class cube artifact 
-        uses: actions/download-artifact@v4 
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with: 
           pattern: be_classes_cube_raw
           merge-multiple: true
@@ -281,7 +281,7 @@ jobs:
         shell: Rscript {0}
         
       - name: upload occ cube
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: be_classes_cube.csv
           path: ./cube_data/be_classes_cube.csv
@@ -305,19 +305,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -334,7 +334,7 @@ jobs:
         shell: Rscript {0}
         
       - name: download cube metadata artifact 
-        uses: actions/download-artifact@v4 
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with: 
           pattern: be_cube_metadata_*
           merge-multiple: true
@@ -349,7 +349,7 @@ jobs:
         shell: Rscript {0}
         
       - name: upload cube metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: be_cube_metadata.csv
           path: ./cube_data/be_cube_metadata.csv

--- a/.github/workflows/get_oxyura_jamaicensis_management.yaml
+++ b/.github/workflows/get_oxyura_jamaicensis_management.yaml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -60,7 +60,7 @@ jobs:
         shell: Rscript {0}
     
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -72,7 +72,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/get_vespa_velutina_management.yaml
+++ b/.github/workflows/get_vespa_velutina_management.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Check if secrets exist
         run: |
@@ -66,19 +66,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -103,7 +103,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@f27e0951b748268e6ac8d91861eeac5bc2bd36a8 # master
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -115,7 +115,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/management-prep.yaml
+++ b/.github/workflows/management-prep.yaml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -70,7 +70,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/run_translations_processing.yaml
+++ b/.github/workflows/run_translations_processing.yaml
@@ -40,18 +40,18 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -69,7 +69,7 @@ jobs:
         shell: Rscript {0}
         
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"

--- a/.github/workflows/run_translations_test.yaml
+++ b/.github/workflows/run_translations_test.yaml
@@ -30,13 +30,13 @@ jobs:
    
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/update_Xenopus_laevis_management.yaml
+++ b/.github/workflows/update_Xenopus_laevis_management.yaml
@@ -25,19 +25,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -60,7 +60,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -72,7 +72,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/update_eu_concern_list.yaml
+++ b/.github/workflows/update_eu_concern_list.yaml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -55,7 +55,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -68,7 +68,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -80,7 +80,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/update_trendOccupancy.yaml
+++ b/.github/workflows/update_trendOccupancy.yaml
@@ -35,19 +35,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -64,7 +64,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -77,7 +77,7 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.1
+        uses: devops-infra/action-commit-push@fc0511fd56cf2eb2631a9601dbc45299de406564 # v0.11.1
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           commit_prefix: "[AUTO]"
@@ -90,7 +90,7 @@ jobs:
           git branch --show-current
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.AUTOMATISATION }}
           target_branch: uat

--- a/.github/workflows/upload_files_direct.yaml
+++ b/.github/workflows/upload_files_direct.yaml
@@ -36,19 +36,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -70,7 +70,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/upload_files_processing.yaml
+++ b/.github/workflows/upload_files_processing.yaml
@@ -35,19 +35,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATISATION }}
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install linux libraries
         run: |
@@ -69,7 +69,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._